### PR TITLE
ユーザー削除ができる

### DIFF
--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -39,7 +39,7 @@ class UserController extends Controller
     }
 
     /**
-     * ユーザー情報編集
+     * ユーザー情報を編集
      *
      * @param UserEditRequest $request
      * @return RedirectResponse

--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -4,11 +4,11 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\User;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
 
 class UserController extends Controller
 {
-    
     /**
      * ユーザー詳細情報を取得
      *
@@ -22,5 +22,18 @@ class UserController extends Controller
         $this->authorize('view', $user_detail);
         
         return view('user/show',['user_detail' => $user_detail]);
+    }
+
+    /**
+     * ユーザー情報を削除
+     *
+     * @return View
+     */
+    public function delete():View
+    {
+        $user = new User();
+        $user->deleteByUserID(Auth::id());
+
+        return view('welcome');
     }
 }

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
@@ -11,6 +12,7 @@ use Laravel\Sanctum\HasApiTokens;
 class User extends Authenticatable
 {
     use HasApiTokens, HasFactory, Notifiable;
+    use SoftDeletes;
 
     /**
      * The attributes that are mass assignable.
@@ -45,12 +47,23 @@ class User extends Authenticatable
     /**
      * ユーザー詳細情報を取得
      *
-     * @param [type] $id
+     * @param int $id
      * @return User|null
      */
     public function findByUserId(int $id):User|null
     {
         return User::find($id);
+    }
+
+    /**
+     * ユーザー情報を削除
+     *
+     * @param int $id
+     * @return void
+     */
+    public function deleteByUserID(int $id)
+    {
+        $this->destroy($id);
     }
 }  
 

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -57,7 +57,7 @@ class User extends Authenticatable
     {
         return User::find($id);
     }
-    
+
     /**
      * ユーザー情報の編集
      *
@@ -79,7 +79,7 @@ class User extends Authenticatable
      * @param int $id
      * @return void
      */
-    public function deleteByUserID(int $id)
+    public function deleteByUserID(int $id):void
     {
         $this->destroy($id);
     }

--- a/twitter/database/migrations/2023_10_02_091749_add_column_to_users_table.php
+++ b/twitter/database/migrations/2023_10_02_091749_add_column_to_users_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up():void
     {
         Schema::table('users', function (Blueprint $table) {
             $table->softDeletes($column = 'deleted_at', $precision = 0);
@@ -23,7 +23,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down():void
     {
         Schema::table('users', function (Blueprint $table) {
             $table->dropColumn('delete_at');

--- a/twitter/database/migrations/2023_10_02_091749_add_column_to_users_table.php
+++ b/twitter/database/migrations/2023_10_02_091749_add_column_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->softDeletes($column = 'deleted_at', $precision = 0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('delete_at');
+        });
+    }
+};

--- a/twitter/database/migrations/2023_10_02_091749_add_column_to_users_table.php
+++ b/twitter/database/migrations/2023_10_02_091749_add_column_to_users_table.php
@@ -26,7 +26,7 @@ return new class extends Migration
     public function down():void
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->dropColumn('delete_at');
+            $table->dropColumn('deleted_at');
         });
     }
 };

--- a/twitter/resources/views/components/header.blade.php
+++ b/twitter/resources/views/components/header.blade.php
@@ -33,7 +33,6 @@
                         <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
                             {{ Auth::user()->name }}
                         </a>
-
                         <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
                             <a class="dropdown-item" href="{{ route('detail',['id' => Auth::id()]) }}">
                                 {{ "プロフィール" }}

--- a/twitter/resources/views/user/show.blade.php
+++ b/twitter/resources/views/user/show.blade.php
@@ -9,6 +9,11 @@
                         <h5 class="card-title">プロフィール</h5>
                         <p class="card-text">名前：{{ $user_detail->name }}</p>
                         <p class="card-text">メール：{{ $user_detail->email }}</p>
+                        <form method="post" action="{{ route('delete') }}">
+                            @csrf
+                            @method('delete')
+                            <input type="submit" value="削除">
+                        </form>
                     </div>
                 </div>
             </div>

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -23,12 +23,12 @@ Route::get('/home', [HomeController::class, 'home'])->name('home');
 
 //ユーザー認証
 Route::group(['middleware' => 'auth'], function () {
-    // ユーザー詳細（プロフィール）表示
+    //ユーザー詳細（プロフィール）表示
     Route::get('detail/{id}', [UserController::class, 'detail'])->name('detail');
     //編集ページ表示
     Route::get('edit', [UserController::class, 'edit'])->name('edit');
     //ユーザー情報編集
     Route::put('update', [UserController::class, 'update'])->name('update');
     //ユーザー削除
-    Route::delete('users/delete',[UserController::class, 'delete'])->name('delete');
+    Route::delete('delete',[UserController::class, 'delete'])->name('delete');
 });

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -21,6 +21,7 @@ Auth::routes();
 
 Route::group(['middleware' => 'auth'], function () {
     Route::get('users/{id}',[UserController::class, 'findByUserId'])->name('show');
+    Route::delete('users/delete',[UserController::class, 'delete'])->name('delete');
 });
 
 Route::get('/home', [HomeController::class, 'index'])->name('home');


### PR DESCRIPTION
# 課題のリンク
ユーザー情報の削除ができる
# 改修内容
・プロフィール画面（show.blade.php）に削除ボタンの追加
・Userテーブルにdeleted_atカラムを追加
# 検証内容
 実際に削除ボタンを押し、データベース上でdeleted_atがNULLから時刻に変更されていることを確認