### PR TITLE
ツイート詳細表示機能追加

### DIFF
--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -58,8 +58,8 @@ class TweetController extends Controller
     public function detail(Request $request):View
     {
         $tweets = new Tweet();
-        $id = $request->id;
-        $tweet = $tweets->detail($id);
+        $tweet_id = $request->id;
+        $tweet = $tweets->detail($tweet_id);
 
         return view('tweet.show', compact('tweet'));
     }

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -48,4 +48,19 @@ class TweetController extends Controller
         
         return view('tweet.index',compact('tweets'));
     }
+
+    /**
+     * ツイート詳細表示
+     *
+     * @param Request $request
+     * @return View
+     */
+    public function detail(Request $request):View
+    {
+        $tweets = new Tweet();
+        $id = $request->id;
+        $tweet = $tweets->detail($id);
+
+        return view('tweet.show', compact('tweet'));
+    }
 }

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -49,11 +49,11 @@ class Tweet extends Model
     /**
      * ツイート詳細表示
      *
-     * @param int $id
+     * @param int $tweet_id
      * @return Tweet
      */
-    public function detail(int $id):Tweet
+    public function detail(int $tweet_id):Tweet
     {
-        return $this->with('user')->find($id);
+        return $this->with('user')->find($tweet_id);
     }
 }

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -45,4 +45,15 @@ class Tweet extends Model
     {
         return $this->with('user')->paginate(5);
     }
+    
+    /**
+     * ツイート詳細表示
+     *
+     * @param int $id
+     * @return Tweet
+     */
+    public function detail(int $id):Tweet
+    {
+        return $this->with('user')->find($id);
+    }
 }

--- a/twitter/resources/views/home.blade.php
+++ b/twitter/resources/views/home.blade.php
@@ -13,7 +13,7 @@
                             {{ session('status') }}
                         </div>
                     @endif
-                    <form method="get" action="{{ route('tweet.tweet') }}">
+                    <form method="get" action="{{ route('tweet') }}">
                         @csrf
                         <input type="submit" value="Tweet">
                     </form>

--- a/twitter/resources/views/tweet/index.blade.php
+++ b/twitter/resources/views/tweet/index.blade.php
@@ -9,10 +9,12 @@
                         <h5 class="card-title">ツイート一覧</h5>
                         @foreach ($tweets as $tweet)
                             <ul class="list-group list-group-flush">
-                                <li class="list-group-item">
-                                    {{ $tweet->user->name }}
-                                    {{ $tweet->tweet }}
-                                </li>
+                                <a href="{{ route('tweet.detail', ['id' => $tweet->id]) }}">
+                                    <li class="list-group-item">
+                                        {{ $tweet->user->name }}
+                                        {{ $tweet->tweet }}
+                                    </li>
+                                </a>
                             </ul>
                         @endforeach
                         {{ $tweets->links() }}

--- a/twitter/resources/views/tweet/show.blade.php
+++ b/twitter/resources/views/tweet/show.blade.php
@@ -1,0 +1,20 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <div class="card text-center">
+                    <div class="card-body">
+                        <h5 class="card-title">ツイート詳細</h5>
+                        <p class="card-text">ユーザー名：{{ $tweet->user->name }}</p>
+                        <p class="card-text">ツイート内容：{{ $tweet->tweet }}</p>
+                        <form method="get" action="{{ route('tweet.index') }}">
+                            <input type="submit" value="戻る">
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -25,27 +25,27 @@ Route::get('/home', [HomeController::class, 'home'])->name('home');
 //ユーザー認証
 Route::group(['middleware' => 'auth'], function () {
     //ユーザー機能
-    Route::group(['prefix' => 'user','as' => 'user.'], function() {
+    Route::group(['prefix' => 'user','as' => 'user'], function() {
         //ユーザー詳細（プロフィール）表示
-        Route::get('detail/{id}', [UserController::class, 'detail'])->name('detail');
+        Route::get('detail/{id}', [UserController::class, 'detail'])->name('.detail');
         //編集ページ表示
-        Route::get('edit', [UserController::class, 'edit'])->name('edit');
+        Route::get('edit', [UserController::class, 'edit'])->name('.edit');
         //ユーザー情報編集
-        Route::put('update', [UserController::class, 'update'])->name('update');
+        Route::put('update', [UserController::class, 'update'])->name('.update');
         //ユーザー削除
-        Route::delete('delete',[UserController::class, 'delete'])->name('delete');
+        Route::delete('delete',[UserController::class, 'delete'])->name('.delete');
         //ユーザー一覧
-        Route::get('index', [UserController::class, 'index'])->name('index');
+        Route::get('index', [UserController::class, 'index'])->name('.index');
     });
     //ツイート機能
-    Route::group(['prefix' => 'tweet', 'as' => 'tweet.'], function(){
+    Route::group(['prefix' => 'tweet', 'as' => 'tweet'], function(){
         //ツイートページ表示
-        Route::get('/', [TweetController::class, 'tweet'])->name('tweet');
+        Route::get('/', [TweetController::class, 'tweet'])->name('');
         //ツイート投稿作成
-        Route::post('create', [TweetController::class, 'create'])->name('create');
+        Route::post('create', [TweetController::class, 'create'])->name('.create');
         //ツイートの一覧表示
-        Route::get('index', [TweetController::class, 'index'])->name('index');
+        Route::get('index', [TweetController::class, 'index'])->name('.index');
         //ツイート詳細表示
-        Route::get('detail', [TweetController::class, 'detail'])->name('detail');
+        Route::get('detail', [TweetController::class, 'detail'])->name('.detail');
     });
 });

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -45,5 +45,7 @@ Route::group(['middleware' => 'auth'], function () {
         Route::post('create', [TweetController::class, 'create'])->name('create');
         //ツイートの一覧表示
         Route::get('index', [TweetController::class, 'index'])->name('index');
+        //ツイート詳細表示
+        Route::get('detail', [TweetController::class, 'detail'])->name('detail');
     });
 });


### PR DESCRIPTION
# 課題のリンク
-ツイート詳細表示機能追加

# 改修内容
- ツイート一覧ページ(tweet/index.blade/php)の１ツイート選択→ツイート詳細ページ(tweet/show.blade.php)に遷移

# キャプチャ

https://github.com/KawanoKohei/twitter-clone/assets/116775795/c627cab0-96f8-45e5-8e61-8d893d0f9672


# 検証内容
- ブラウザ上で確認
