### PR TITLE
ツイート編集機能の追加

### DIFF
--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -63,4 +63,21 @@ class TweetController extends Controller
 
         return view('tweet.show', compact('tweet'));
     }
+
+    /**
+     * ツイート編集画面の表示
+     *
+     * @return View
+     */
+    public function edit():View
+    {
+        
+
+        return view('tweet.edit');
+    }
+
+    public function update(CreateTweetRequest $request)
+    {
+
+    }
 }

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -102,9 +102,9 @@ class TweetController extends Controller
 
             return redirect()->route('tweet.detail', $tweet_id)->with('success', '更新しました！');
         } catch(\Exception $e) {
-            DB::rollback();
             Log::error($e);
-
+            DB::rollback();
+            
             return redirect()->route('tweet.detail', $tweet_id)->with('error', '更新中にエラーが発生しました！');
         }
     }

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -59,10 +59,10 @@ class TweetController extends Controller
      * @param Request $request
      * @return View
      */
-    public function detail(int $tweet_id):View
+    public function detail(int $tweetId):View
     {
         $tweets = new Tweet();
-        $tweet = $tweets->detail($tweet_id);
+        $tweet = $tweets->detail($tweetId);
 
         return view('tweet.show', compact('tweet'));
     }
@@ -72,16 +72,14 @@ class TweetController extends Controller
      *
      * @return View|RedirectResponse
      */
-    public function edit(int $tweet_id, Tweet $tweet):View|RedirectResponse
+    public function edit(int $tweetId, Tweet $tweet):View|RedirectResponse
     {
-        $tweet_text = $tweet->detail($tweet_id);
-        $boolFlag = false;
-        if($tweet_text->user_id === Auth::id()) $boolFlag = true;
+        $tweetText = $tweet->detail($tweetId);
 
-        if ($boolFlag) {
-            return view('tweet.edit', compact('tweet_text'));
+        if ($tweetText->user_id === Auth::id()) {
+            return view('tweet.edit', compact('tweetText'));
         } else {
-            return redirect()->route('tweet.detail', $tweet_id)->with('message', '他のユーザーのツイートを編集できません！！！');
+            return redirect()->route('tweet.detail', $tweetId)->with('message', '他のユーザーのツイートを編集できません！！！');
         };
     }
 
@@ -96,17 +94,17 @@ class TweetController extends Controller
         try {
             DB::beginTransaction();
             $tweet = new Tweet();
-            $tweet_id = $request->id;
-            $tweet_text = $request->tweet;
-            $tweet = $tweet->updateTweet($tweet_id, $tweet_text);
+            $tweetId = $request->id;
+            $tweetText = $request->tweet;
+            $tweet = $tweet->updateTweet($tweetId, $tweetText);
             DB::commit();
 
-            return redirect()->route('tweet.detail', $tweet_id)->with('success', '更新しました！');
+            return redirect()->route('tweet.detail', $tweetId)->with('success', '更新しました！');
         } catch(\Exception $e) {
             Log::error($e);
             DB::rollback();
             
-            return redirect()->route('tweet.detail', $tweet_id)->with('error', '更新中にエラーが発生しました！');
+            return redirect()->route('tweet.detail', $tweetId)->with('error', '更新中にエラーが発生しました！');
         }
     }
 }

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -72,13 +72,14 @@ class TweetController extends Controller
      *
      * @return View|RedirectResponse
      */
-    public function edit(int $tweet_id):View|RedirectResponse
+    public function edit(int $tweet_id, Tweet $tweet):View|RedirectResponse
     {
-        $tweets = new Tweet();
-        $tweet = $tweets->detail($tweet_id);
+        $tweet_text = $tweet->detail($tweet_id);
+        $boolFlag = false;
+        if($tweet_text->user_id === Auth::id()) $boolFlag = true;
 
-        if ($tweet->user_id == Auth::id()) {
-            return view('tweet.edit', compact('tweet'));
+        if ($boolFlag) {
+            return view('tweet.edit', compact('tweet_text'));
         } else {
             return redirect()->route('tweet.detail', $tweet_id)->with('message', '他のユーザーのツイートを編集できません！！！');
         };
@@ -94,10 +95,10 @@ class TweetController extends Controller
     {
         try {
             DB::beginTransaction();
-            $tweets = new Tweet();
+            $tweet = new Tweet();
             $tweet_id = $request->id;
-            $tweet = $request->tweet;
-            $tweet = $tweets->updateData($tweet_id, $tweet);
+            $tweet_text = $request->tweet;
+            $tweet = $tweet->updateTweet($tweet_id, $tweet_text);
             DB::commit();
 
             return redirect()->route('tweet.detail', $tweet_id)->with('success', '更新しました！');

--- a/twitter/app/Http/Requests/CreateTweetRequest.php
+++ b/twitter/app/Http/Requests/CreateTweetRequest.php
@@ -24,7 +24,7 @@ class CreateTweetRequest extends FormRequest
     public function rules():array
     {
         return [
-            'tweet' => 'required|between:0,200',
+            'tweet' => 'required|between:1,200',
         ];
     }
 

--- a/twitter/app/Http/Requests/UpdateTweetRequest.php
+++ b/twitter/app/Http/Requests/UpdateTweetRequest.php
@@ -24,7 +24,7 @@ class UpdateTweetRequest extends FormRequest
     public function rules():array
     {
         return [
-            'tweet' => 'required|between:0,200',
+            'tweet' => 'required|between:1,200',
         ];
     }
 

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -49,25 +49,25 @@ class Tweet extends Model
     /**
      * ツイート詳細表示
      *
-     * @param int $tweet_id
+     * @param int $tweetId
      * @return Tweet
      */
-    public function detail(int $tweet_id):Tweet
+    public function detail(int $tweetId):Tweet
     {
-        return $this->with('user')->find($tweet_id);
+        return $this->with('user')->find($tweetId);
     }
 
     /**
      * ツイートを更新
      *
-     * @param integer $tweet_id
-     * @param string $tweet_text
+     * @param integer $tweetId
+     * @param string $tweetText
      * @return Tweet
      */
-    public function updateTweet(int $tweet_id, string $tweet_text):Tweet
+    public function updateTweet(int $tweetId, string $tweetText):Tweet
     {
-        $tweet = Tweet::find($tweet_id);
-        $tweet->tweet = $tweet_text;
+        $tweet = Tweet::find($tweetId);
+        $tweet->tweet = $tweetText;
         $tweet->update();
 
         return $tweet;

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -61,15 +61,15 @@ class Tweet extends Model
      * ツイートを更新
      *
      * @param integer $tweet_id
-     * @param string $tweet
+     * @param string $tweet_text
      * @return Tweet
      */
-    public function updateData(int $tweet_id, string $tweet):Tweet
+    public function updateTweet(int $tweet_id, string $tweet_text):Tweet
     {
-        $data = Tweet::find($tweet_id);
-        $data->tweet = $tweet;
-        $data->update();
+        $tweet = Tweet::find($tweet_id);
+        $tweet->tweet = $tweet_text;
+        $tweet->update();
 
-        return $data;
+        return $tweet;
     }
 }

--- a/twitter/resources/views/home.blade.php
+++ b/twitter/resources/views/home.blade.php
@@ -13,10 +13,7 @@
                                 {{ session('status') }}
                             </div>
                         @endif
-                        <form method="get" action="{{ route('tweet') }}">
-                            @csrf
-                            <input type="submit" value="Tweet">
-                        </form>
+                        <button onclick="location.href='{{ route('tweet') }}'">ツイート</button>
                         <br>
                     </div>
                 </div>

--- a/twitter/resources/views/tweet/edit.blade.php
+++ b/twitter/resources/views/tweet/edit.blade.php
@@ -6,20 +6,18 @@
             <div class="col-md-8">
                 <div class="card text-center">
                     <div class="card-body">
-                        <form method="post" action="{{ route('tweet.update',$tweet->id)}} ">
+                        <form method="post" action="{{ route('tweet.update',$tweet_text->id)}} ">
                             @csrf
                             @method('put')
                             @error('tweet')
                                 <h5>{{ $message }}</h5>
                             @enderror
                             <div class="card-text">
-                                <textarea name="tweet" cols="70" rows="5" value="{{ old('tweet') ?? $tweet->tweet }}"></textarea>
+                                <textarea name="tweet" cols="70" rows="5" value="{{ old('tweet') ?? $tweet_text->tweet }}"></textarea>
                             </div>
                             <input type="submit" value="保存">
                         </form>
-                        <form method="get" action="{{ route('tweet.detail',$tweet->id) }}">
-                            <input type="submit" value="戻る">
-                        </form>
+                        <button onclick="location.href='{{ route('tweet.index') }}'">戻る</button>
                     </div>
                 </div>
             </div>

--- a/twitter/resources/views/tweet/edit.blade.php
+++ b/twitter/resources/views/tweet/edit.blade.php
@@ -1,0 +1,29 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <div class="card text-center">
+                    <div class="card-body">
+                        <form method="post" action="{{ route('tweet.update') }}">
+                            @csrf
+                            @method('put')
+                            @error('tweet')
+                                <h5>{{ $message }}</h5>
+                            @enderror
+                            <div class="card-text">
+                                <input type="textarea" name="tweet">
+                            </div>
+                            <input type="submit" value="編集">
+                        </form>
+                        <form method="get" action="{{ route('home') }}">
+                            @csrf
+                            <input type="submit" value="キャンセル">
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/twitter/resources/views/tweet/edit.blade.php
+++ b/twitter/resources/views/tweet/edit.blade.php
@@ -6,14 +6,14 @@
             <div class="col-md-8">
                 <div class="card text-center">
                     <div class="card-body">
-                        <form method="post" action="{{ route('tweet.update',$tweet_text->id)}} ">
+                        <form method="post" action="{{ route('tweet.update',$tweetText->id)}} ">
                             @csrf
                             @method('put')
                             @error('tweet')
                                 <h5>{{ $message }}</h5>
                             @enderror
                             <div class="card-text">
-                                <textarea name="tweet" cols="70" rows="5" value="{{ old('tweet') ?? $tweet_text->tweet }}"></textarea>
+                                <textarea name="tweet" cols="70" rows="5" value="{{ old('tweet') ?? $tweetText->tweet }}"></textarea>
                             </div>
                             <input type="submit" value="保存">
                         </form>

--- a/twitter/resources/views/tweet/show.blade.php
+++ b/twitter/resources/views/tweet/show.blade.php
@@ -9,6 +9,9 @@
                         <h5 class="card-title">ツイート詳細</h5>
                         <p class="card-text">ユーザー名：{{ $tweet->user->name }}</p>
                         <p class="card-text">ツイート内容：{{ $tweet->tweet }}</p>
+                        <form method="get" action="{{ route('tweet.edit') }}">
+                            <input type="submit" value="編集">
+                        </form>
                         <form method="get" action="{{ route('tweet.index') }}">
                             <input type="submit" value="戻る">
                         </form>

--- a/twitter/resources/views/tweet/show.blade.php
+++ b/twitter/resources/views/tweet/show.blade.php
@@ -22,13 +22,9 @@
                         <p class="card-text">{{ $tweet->user->name }}</p>
                         <p class="card-text">{{ $tweet->tweet }}</p>
                         @if ($tweet->user_id == Auth::id())
-                            <form method="get" action="{{ route('tweet.edit', $tweet->id) }}">
-                                <input type="submit" value="編集">
-                            </form>
+                            <button onclick="location.href='{{ route('tweet.edit', $tweet->id) }}'">編集</button>
                         @endif
-                        <form method="get" action="{{ route('tweet.index') }}">
-                            <input type="submit" value="戻る">
-                        </form>
+                        <button onclick="location.href='{{ route('tweet.index') }}'">戻る</button>
                     </div>
                 </div>
             </div>

--- a/twitter/resources/views/user/edit.blade.php
+++ b/twitter/resources/views/user/edit.blade.php
@@ -19,10 +19,7 @@
                             <p class="card-text">メール：<input type="email" name="email" value="{{ $user->email }}" ></p>
                             <input type="submit" value="保存">
                         </form>
-                        <form method="get" action="{{ route('user.detail',['id' => Auth::id()]) }}">
-                            @csrf
-                            <input type="submit" value="キャンセル">
-                        </form>
+                        <button onclick="location.href='{{ route('user.detail',['id' => Auth::id()]) }}'">戻る</button>
                     </div>
                 </div>
             </div>

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -25,7 +25,8 @@ Route::get('/home', [HomeController::class, 'home'])->name('home');
 //ユーザー認証
 Route::group(['middleware' => 'auth'], function () {
     //ユーザー機能
-    Route::group(['prefix' => 'user','as' => 'user'], function() {
+    Route::group(['prefix' => 'user','as' => 'user'], function()
+    {
         //ユーザー詳細（プロフィール）表示
         Route::get('detail/{id}', [UserController::class, 'detail'])->name('.detail');
         //編集ページ表示
@@ -38,7 +39,8 @@ Route::group(['middleware' => 'auth'], function () {
         Route::get('index', [UserController::class, 'index'])->name('.index');
     });
     //ツイート機能
-    Route::group(['prefix' => 'tweet', 'as' => 'tweet'], function(){
+    Route::group(['prefix' => 'tweet', 'as' => 'tweet'], function()
+    {
         //ツイートページ表示
         Route::get('/', [TweetController::class, 'tweet'])->name('');
         //ツイート投稿作成
@@ -47,5 +49,9 @@ Route::group(['middleware' => 'auth'], function () {
         Route::get('index', [TweetController::class, 'index'])->name('.index');
         //ツイート詳細表示
         Route::get('detail', [TweetController::class, 'detail'])->name('.detail');
+        //ツイート編集ページ表示
+        Route::get('edit', [TweetController::class, 'edit'])->name('.edit');
+        //ツイート編集
+        Route::put('update', [TweetController::class, 'update'])->name('.update');
     });
 });


### PR DESCRIPTION
# 課題のリンク

- ツイート編集機能の追加

# 改修内容
- ツイート詳細ページ(show.balde.php)に編集ボタンの追加
- ただし、ユーザー本人のツイートにしか編集ボタンは表示されない仕様
- 編集ボタン押すと、新規作成したツイート編集ページ(edit.blade.php)に遷移
- 編集ツイート用のフォームリクエスト(UpdateTweetRequest.php)を作成
- コントローラ(TweetController.php)内のupdateメソッドにおいて、データベースの整合性の維持やエラー時のエラーログの記録のためにトランザクションを適用。ただし、今回の更新においてはあまり意味をなさないので練習の意が強め。

# キャプチャ

https://github.com/keeee21/twitter-clone/assets/116775795/792bbb84-75f4-4d05-b8b2-4da268c8c8d1

# 検証内容
- 更新されているか目視で確認