### PR TITLE
フォロー機能の追加

### DIFF
--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -70,6 +70,19 @@ class UserController extends Controller
     }
 
     /**
+     * ユーザー一覧の表示
+     *
+     * @return View
+     */
+    public function index(Follower $follower):View
+    {
+        $user = new User();
+        $users = $user->index();
+
+        return view('user.index',compact('users','follower'));
+    }
+
+    /**
      * フォロー
      *
      * @param Follower $follower
@@ -79,17 +92,21 @@ class UserController extends Controller
     public function follow(Follower $follower, User $user):RedirectResponse
     {
         try {
+            $result = 'already';
+            $flashMessage = '既にフォローしています';
+
             if (!$follower->isFollowing(Auth::id(), $user->id))
             {
                 $follower->following_id = Auth::id();
                 $follower->followed_id = $user->id;
                 $this->authorize('follow',$follower);
                 Auth::user()->follow($user->id);
-            } else{
-                return redirect()->route('user.index')->with('already', '既にフォローしています');
-            }
 
-            return redirect()->route('user.index')->with('success', 'フォローしました！');
+                $result = 'success';
+                $flashMessage = 'フォローしました！';
+            } 
+
+            return redirect()->route('user.index')->with($result, $flashMessage);
         } catch(\Exception $e) {
             Log::error($e);
 
@@ -103,17 +120,21 @@ class UserController extends Controller
      * @param User $user
      * @return void
      */
-    public function unfollow(Follower $follower, User $user):RedirectResponse
+    public function unfollow(Follower $follower, User $user)
     {
         try {
+            $result = 'already';
+            $flashMessage = '既にフォロー解除しています';
+
             if ($follower->isFollowing(Auth::id(), $user->id))
             {
                 Auth::user()->unfollow($user->id);
-            } else{
-                return redirect()->route('user.index')->with('already', '既にフォロー解除しています');
-            }
+                
+                $result = 'success';
+                $flashMessage = 'フォロー解除しました！';
+            } 
 
-            return redirect()->route('user.index')->with('success', 'フォロー解除しました！');
+            return redirect()->route('user.index')->with($result, $flashMessage);
         } catch(\Exception $e) {
             Log::error($e);
 

--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -92,11 +92,11 @@ class UserController extends Controller
     public function follow(Follower $follower, User $user):RedirectResponse
     {
         try {
-            $follower->follower_id = Auth::id();
+            $follower->following_id = Auth::id();
             $bool = $user->isFollowing($user->id, Auth::id());
             if (!$bool)
             {
-                $follower->following_id = $user->id;
+                $follower->followed_id = $user->id;
                 $this->authorize('follow',$follower);
                 $follower->follow();
             } else{

--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -92,13 +92,13 @@ class UserController extends Controller
     public function follow(Follower $follower, User $user):RedirectResponse
     {
         try {
-            $follower->following_id = Auth::id();
             $bool = $user->isFollowing(Auth::id(), $user->id);
             if (!$bool)
             {
+                $follower->following_id = Auth::id();
                 $follower->followed_id = $user->id;
                 $this->authorize('follow',$follower);
-                $follower->follow();
+                Auth::user()->follow($user->id);
             } else{
                 return redirect()->route('user.index')->with('already', '既にフォローしています');
             }
@@ -114,17 +114,16 @@ class UserController extends Controller
     /**
      * フォロー解除
      *
-     * @param Follower $follower
      * @param User $user
      * @return void
      */
-    public function unfollow(Follower $follower, User $user):RedirectResponse
+    public function unfollow(User $user):RedirectResponse
     {
         try {
             $bool = $user->isFollowing(Auth::id(), $user->id);
             if ($bool)
             {
-                $follower->unfollow(Auth::id(), $user->id);
+                Auth::user()->unfollow($user->id);
             } else{
                 return redirect()->route('user.index')->with('already', '既にフォロー解除しています');
             }

--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -93,7 +93,7 @@ class UserController extends Controller
     {
         try {
             $follower->following_id = Auth::id();
-            $bool = $user->isFollowing($user->id, Auth::id());
+            $bool = $user->isFollowing(Auth::id(), $user->id);
             if (!$bool)
             {
                 $follower->followed_id = $user->id;
@@ -121,10 +121,10 @@ class UserController extends Controller
     public function unfollow(Follower $follower, User $user):RedirectResponse
     {
         try {
-            $bool = $user->isFollowing($user->id, Auth::id());
+            $bool = $user->isFollowing(Auth::id(), $user->id);
             if ($bool)
             {
-                $follower->unfollow($user->id, Auth::id());
+                $follower->unfollow(Auth::id(), $user->id);
             } else{
                 return redirect()->route('user.index')->with('already', '既にフォロー解除しています');
             }

--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -70,19 +70,6 @@ class UserController extends Controller
     }
 
     /**
-     * ユーザー一覧の表示
-     *
-     * @return View
-     */
-    public function index():View
-    {
-        $user = new User();
-        $users = $user->index();
-        
-        return view('user.index',compact('users'));
-    }
-
-    /**
      * フォロー
      *
      * @param Follower $follower
@@ -92,8 +79,7 @@ class UserController extends Controller
     public function follow(Follower $follower, User $user):RedirectResponse
     {
         try {
-            $bool = $user->isFollowing(Auth::id(), $user->id);
-            if (!$bool)
+            if (!$follower->isFollowing(Auth::id(), $user->id))
             {
                 $follower->following_id = Auth::id();
                 $follower->followed_id = $user->id;
@@ -117,11 +103,10 @@ class UserController extends Controller
      * @param User $user
      * @return void
      */
-    public function unfollow(User $user):RedirectResponse
+    public function unfollow(Follower $follower, User $user):RedirectResponse
     {
         try {
-            $bool = $user->isFollowing(Auth::id(), $user->id);
-            if ($bool)
+            if ($follower->isFollowing(Auth::id(), $user->id))
             {
                 Auth::user()->unfollow($user->id);
             } else{

--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -97,6 +97,7 @@ class UserController extends Controller
             if (!$bool)
             {
                 $follower->following_id = $user->id;
+                $this->authorize('follow',$follower);
                 $follower->follow();
             } else{
                 return redirect()->route('user.index')->with('already', '既にフォローしています');
@@ -134,6 +135,5 @@ class UserController extends Controller
 
             return redirect()->route('user.index')->with('error', 'フォロー解除に失敗しました！');
         }
-
     }
 }

--- a/twitter/app/Models/Follower.php
+++ b/twitter/app/Models/Follower.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Follower extends Model
+{
+    use HasFactory;
+}

--- a/twitter/app/Models/Follower.php
+++ b/twitter/app/Models/Follower.php
@@ -10,4 +10,16 @@ class Follower extends Model
     use HasFactory;
 
     protected $fillable = ['following_id', 'followed_id'];
+
+    /**
+     * 既存フォローの確認
+     *
+     * @param integer $id
+     * @param integer $loginUserId
+     * @return boolean
+     */
+    public function isFollowing(int $loginUserId, int $id ): bool
+    {
+        return Follower::where('following_id', $loginUserId)->where('followed_id', $id)->exists();
+    }
 }

--- a/twitter/app/Models/Follower.php
+++ b/twitter/app/Models/Follower.php
@@ -10,27 +10,4 @@ class Follower extends Model
     use HasFactory;
 
     protected $fillable = ['following_id', 'followed_id'];
-
-    /**
-     * フォロー
-     *
-     * @return void
-     */
-    public function follow():void
-    {
-        $this->save();
-    }
-
-    /**
-     * フォロー解除
-     *
-     * @param integer $id
-     * @param integer $loginUserId
-     * @return void
-     */
-    public function unfollow(int $loginUserId, int $id):void
-    {
-        $follow = Follower::where('following_id', $loginUserId)->where('followed_id', $id)->first();
-        $follow->delete();
-    }
 }

--- a/twitter/app/Models/Follower.php
+++ b/twitter/app/Models/Follower.php
@@ -9,7 +9,7 @@ class Follower extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['following_id', 'follower_id'];
+    protected $fillable = ['following_id', 'followed_id'];
 
     /**
      * フォロー
@@ -28,9 +28,9 @@ class Follower extends Model
      * @param integer $loginUserId
      * @return void
      */
-    public function unfollow(int $id, int $loginUserId):void
+    public function unfollow(int $loginUserId, int $id):void
     {
-        $follow = Follower::where('following_id',$id)->where('follower_id', $loginUserId)->first();
+        $follow = Follower::where('following_id', $loginUserId)->where('followed_id', $id)->first();
         $follow->delete();
     }
 }

--- a/twitter/app/Models/Follower.php
+++ b/twitter/app/Models/Follower.php
@@ -14,12 +14,12 @@ class Follower extends Model
     /**
      * 既存フォローの確認
      *
-     * @param integer $id
-     * @param integer $loginUserId
+     * @param integer $FollowingId
+     * @param integer $followedId
      * @return boolean
      */
-    public function isFollowing(int $loginUserId, int $id ): bool
+    public function isFollowing(int $FollowingId, int $followedId ): bool
     {
-        return Follower::where('following_id', $loginUserId)->where('followed_id', $id)->exists();
+        return Follower::where('following_id', $FollowingId)->where('followed_id', $followedId)->exists();
     }
 }

--- a/twitter/app/Models/Follower.php
+++ b/twitter/app/Models/Follower.php
@@ -8,4 +8,29 @@ use Illuminate\Database\Eloquent\Model;
 class Follower extends Model
 {
     use HasFactory;
+
+    protected $fillable = ['following_id', 'follower_id'];
+
+    /**
+     * フォロー
+     *
+     * @return void
+     */
+    public function follow():void
+    {
+        $this->save();
+    }
+
+    /**
+     * フォロー解除
+     *
+     * @param integer $id
+     * @param integer $loginUserId
+     * @return void
+     */
+    public function unfollow(int $id, int $loginUserId):void
+    {
+        $follow = Follower::where('following_id',$id)->where('follower_id', $loginUserId)->first();
+        $follow->delete();
+    }
 }

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -51,23 +51,23 @@ class User extends Authenticatable
     ];
 
     /**
-     * フォローデータ取得リレーション
+     * フォローデータリレーション
      *
      * @return BelongsToMany
      */
     public function follows(): BelongsToMany
     {
-        return $this->belongsToMany(self::class, 'followers', 'following_id', 'follower_id');
+        return $this->belongsToMany(self::class, 'followers', 'following_id', 'followed_id');
     }
 
     /**
-     * フォロワーデータ取得リレーション
+     * フォロワーデータリレーション
      *
      * @return BelongsToMany
      */
     public function followers(): BelongsToMany
     {
-        return $this->belongsToMany(Follower::class, 'follower_id', 'following_id');
+        return $this->belongsToMany(self::class, 'followers', 'followed_id', 'following_id');
     }
 
     /**

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -57,7 +57,7 @@ class User extends Authenticatable
      */
     public function follows(): BelongsToMany
     {
-        return $this->belongsToMany(self::class, 'followers', 'following_id', 'followed_id');
+        return $this->belongsToMany(self::class, 'followers', 'following_id', 'followed_id')->withPivot('created_at','updated_at');
     }
 
     /**
@@ -127,6 +127,28 @@ class User extends Authenticatable
     public function isFollowing(int $loginUserId, int $id ): bool
     {
         return Follower::where('following_id', $loginUserId)->where('followed_id', $id)->exists();
+    }
+
+    /**
+     * フォロー
+     *
+     * @param integer $user_id
+     * @return void
+     */
+    public function follow(int $user_id):void
+    {
+        $this->follows()->attach($user_id);
+    }
+
+    /**
+     * フォロー解除
+     *
+     * @param integer $user_id
+     * @return void
+     */
+    public function unfollow(int $user_id):void
+    {
+        $this->follows()->detach($user_id);
     }
 }  
 

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -5,8 +5,8 @@ namespace App\Models;
 use App\Models\Follower;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Http\Request;
 use Illuminate\Notifications\Notifiable;
@@ -57,7 +57,8 @@ class User extends Authenticatable
      */
     public function follows(): BelongsToMany
     {
-        return $this->belongsToMany(self::class, 'followers', 'following_id', 'followed_id')->withPivot('created_at','updated_at');
+        return $this->belongsToMany(self::class, 'followers', 'following_id', 'followed_id')
+            ->withPivot('created_at','updated_at');
     }
 
     /**
@@ -115,18 +116,6 @@ class User extends Authenticatable
     public function index():LengthAwarePaginator
     {
         return $this->orderBy('id', 'asc')->paginate(5);
-    }
-
-    /**
-     * 既存フォローの確認
-     *
-     * @param integer $id
-     * @param integer $loginUserId
-     * @return boolean
-     */
-    public function isFollowing(int $loginUserId, int $id ): bool
-    {
-        return Follower::where('following_id', $loginUserId)->where('followed_id', $id)->exists();
     }
 
     /**

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -124,9 +124,9 @@ class User extends Authenticatable
      * @param integer $loginUserId
      * @return boolean
      */
-    public function isFollowing(int $id, int $loginUserId): bool
+    public function isFollowing(int $loginUserId, int $id ): bool
     {
-        return Follower::where('following_id',$id)->where('follower_id', $loginUserId)->exists();
+        return Follower::where('following_id', $loginUserId)->where('followed_id', $id)->exists();
     }
 }  
 

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -50,8 +50,6 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
     ];
 
-    //following_id -> ファローされた人、
-    //follower_id　ー＞　フォローした人
     /**
      * フォローデータ取得リレーション
      *

--- a/twitter/app/Policies/FollowerPolicy.php
+++ b/twitter/app/Policies/FollowerPolicy.php
@@ -29,6 +29,6 @@ class FollowerPolicy
      */
     public function follow(User $user, Follower $follow):bool
     {
-        return $user->id !== $follow->following_id;
+        return $user->id !== $follow->followed_id;
     }
 }

--- a/twitter/app/Policies/FollowerPolicy.php
+++ b/twitter/app/Policies/FollowerPolicy.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\Follower;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class FollowerPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Create a new policy instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * 自分自身へのフォローを防ぐ
+     *
+     * @param User $user
+     * @param Follower $follow
+     * @return bool
+     */
+    public function follow(User $user, Follower $follow):bool
+    {
+        return $user->id !== $follow->following_id;
+    }
+}

--- a/twitter/database/migrations/2023_10_18_121637_create_followers_table.php
+++ b/twitter/database/migrations/2023_10_18_121637_create_followers_table.php
@@ -15,9 +15,12 @@ return new class extends Migration
     {
         Schema::create('followers', function (Blueprint $table) {
             $table->id();
-            $table->foreign('following_id')->references('id')->on('users');
-            $table->foreign('follower_id')->references('id')->on('users');
+            $table->unsignedBigInteger('following_id');
+            $table->unsignedBigInteger('followed_id');
             $table->timestamps();
+
+            $table->foreign('following_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('followed_id')->references('id')->on('users')->onDelete('cascade');
         });
     }
 

--- a/twitter/database/migrations/2023_10_18_121637_create_followers_table.php
+++ b/twitter/database/migrations/2023_10_18_121637_create_followers_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('followers', function (Blueprint $table) {
+            $table->id();
+            $table->foreign('following_id')->references('id')->on('users');
+            $table->foreign('follower_id')->references('id')->on('users');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('followers');
+    }
+};

--- a/twitter/resources/views/home.blade.php
+++ b/twitter/resources/views/home.blade.php
@@ -13,7 +13,7 @@
                                 {{ session('status') }}
                             </div>
                         @endif
-                        <button onclick="location.href='{{ route('tweet') }}'">ツイート</button>
+                        <button onclick="location.href='{{ route('tweet.') }}'">ツイート</button>
                         <br>
                     </div>
                 </div>

--- a/twitter/resources/views/user/index.blade.php
+++ b/twitter/resources/views/user/index.blade.php
@@ -27,7 +27,7 @@
                                         <p>{{ $user['name'] }}</p>
                                     </div>
                                     @if(Auth::id() !== $user->id)
-                                        @if(Auth::user()->isFollowing($user->id, Auth::id()))
+                                        @if(Auth::user()->isFollowing(Auth::id(), $user->id))
                                             <form method="post" action="{{ route('user.unfollow', $user) }}">
                                                 @csrf
                                                 @method('delete')

--- a/twitter/resources/views/user/index.blade.php
+++ b/twitter/resources/views/user/index.blade.php
@@ -27,7 +27,7 @@
                                         <p>{{ $user['name'] }}</p>
                                     </div>
                                     @if(Auth::id() !== $user->id)
-                                        @if(Auth::user()->isFollowing(Auth::id(), $user->id))
+                                        @if($follower->isFollowing(Auth::id(), $user->id))
                                             <form method="post" action="{{ route('user.unfollow', $user) }}">
                                                 @csrf
                                                 @method('delete')

--- a/twitter/resources/views/user/index.blade.php
+++ b/twitter/resources/views/user/index.blade.php
@@ -28,13 +28,13 @@
                                     </div>
                                     @if(Auth::id() !== $user->id)
                                         @if(Auth::user()->isFollowing($user->id, Auth::id()))
-                                            <form method="post" action="{{ route('unfollow', $user) }}">
+                                            <form method="post" action="{{ route('user.unfollow', $user) }}">
                                                 @csrf
                                                 @method('delete')
                                                 <input type="submit" value="フォロー解除">
                                             </form>
                                         @else
-                                            <form method="post" action="{{ route('follow', $user) }}">
+                                            <form method="post" action="{{ route('user.follow', $user) }}">
                                                 @csrf
                                                 <input type="submit" value="フォロー">
                                             </form>

--- a/twitter/resources/views/user/index.blade.php
+++ b/twitter/resources/views/user/index.blade.php
@@ -7,10 +7,41 @@
                 <div class="card text-center">
                     <div class="card-body">
                         <h5 class="card-title">登録ユーザー</h5>
-                        @foreach ($users as $user)
-                            <div class="card-text">
-                                <p>・{{ $user['name'] }}</p>
+                        @if (session('success'))
+                            <div class="alert alert-success">
+                                {{ session('success') }}
                             </div>
+                        @elseif (session('error'))
+                            <div class="alert alert-danger">
+                                {{ session('error') }}
+                            </div>
+                        @elseif (session('already'))
+                            <div class="alert alert-warning">
+                                {{ session('already') }}
+                            </div>
+                        @endif
+                        @foreach ($users as $user)
+                            <ul class="list-group list-group-flush">
+                                <li class="list-group-item">
+                                    <div class="card-text">
+                                        <p>{{ $user['name'] }}</p>
+                                    </div>
+                                    @if(Auth::id() !== $user->id)
+                                        @if(Auth::user()->isFollowing($user->id, Auth::id()))
+                                            <form method="post" action="{{ route('unfollow', $user) }}">
+                                                @csrf
+                                                @method('delete')
+                                                <input type="submit" value="フォロー解除">
+                                            </form>
+                                        @else
+                                            <form method="post" action="{{ route('follow', $user) }}">
+                                                @csrf
+                                                <input type="submit" value="フォロー">
+                                            </form>
+                                        @endif
+                                    @endif
+                                </li>
+                            </ul>
                         @endforeach
                         {{ $users->links() }}
                     </div>

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -37,6 +37,10 @@ Route::group(['middleware' => 'auth'], function () {
         Route::delete('delete',[UserController::class, 'delete'])->name('.delete');
         //ユーザー一覧
         Route::get('index', [UserController::class, 'index'])->name('.index');
+        //フォロー
+        Route::post('follow/{user}', [UserController::class, 'follow'])->name('.follow');
+        //フォロー解除
+        Route::delete('unfollow/{user}', [UserController::class, 'unfollow'])->name('.unfollow');
     });
     //ツイート機能
     Route::group(['prefix' => 'tweet', 'as' => 'tweet'], function()
@@ -56,8 +60,4 @@ Route::group(['middleware' => 'auth'], function () {
         //ツイートの削除
         Route::delete('delete/{tweet}', [TweetController::class, 'delete'])->name('.delete');
     });
-    //フォロー
-    Route::post('follow/{user}', [UserController::class, 'follow'])->name('follow');
-    //フォロー解除
-    Route::delete('unfollow/{user}', [UserController::class, 'unfollow'])->name('unfollow');
 });

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\UserController;
-use App\Http\Controllers\TweetController;
 use App\Http\Controllers\HomeController;
+use App\Http\Controllers\TweetController;
+use App\Http\Controllers\UserController;
+use Illuminate\Support\Facades\Route;
 
 /*
 |--------------------------------------------------------------------------

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -25,39 +25,39 @@ Route::get('/home', [HomeController::class, 'home'])->name('home');
 //ユーザー認証
 Route::group(['middleware' => 'auth'], function () {
     //ユーザー機能
-    Route::group(['prefix' => 'user','as' => 'user'], function()
+    Route::group(['prefix' => 'user','as' => 'user.'], function()
     {
         //ユーザー詳細（プロフィール）表示
-        Route::get('detail/{id}', [UserController::class, 'detail'])->name('.detail');
+        Route::get('detail/{id}', [UserController::class, 'detail'])->name('detail');
         //編集ページ表示
-        Route::get('edit', [UserController::class, 'edit'])->name('.edit');
+        Route::get('edit', [UserController::class, 'edit'])->name('edit');
         //ユーザー情報編集
-        Route::put('update', [UserController::class, 'update'])->name('.update');
+        Route::put('update', [UserController::class, 'update'])->name('update');
         //ユーザー削除
-        Route::delete('delete',[UserController::class, 'delete'])->name('.delete');
+        Route::delete('delete',[UserController::class, 'delete'])->name('delete');
         //ユーザー一覧
-        Route::get('index', [UserController::class, 'index'])->name('.index');
+        Route::get('index', [UserController::class, 'index'])->name('index');
         //フォロー
-        Route::post('follow/{user}', [UserController::class, 'follow'])->name('.follow');
+        Route::post('follow/{user}', [UserController::class, 'follow'])->name('follow');
         //フォロー解除
-        Route::delete('unfollow/{user}', [UserController::class, 'unfollow'])->name('.unfollow');
+        Route::delete('unfollow/{user}', [UserController::class, 'unfollow'])->name('unfollow');
     });
     //ツイート機能
-    Route::group(['prefix' => 'tweet', 'as' => 'tweet'], function()
+    Route::group(['prefix' => 'tweet', 'as' => 'tweet.'], function()
     {
         //ツイートページ表示
         Route::get('/', [TweetController::class, 'tweet'])->name('');
         //ツイート投稿作成
-        Route::post('create', [TweetController::class, 'create'])->name('.create');
+        Route::post('create', [TweetController::class, 'create'])->name('create');
         //ツイートの一覧表示
-        Route::get('index', [TweetController::class, 'index'])->name('.index');
+        Route::get('index', [TweetController::class, 'index'])->name('index');
         //ツイート詳細表示
-        Route::get('detail/{tweet}', [TweetController::class, 'detail'])->name('.detail');
+        Route::get('detail/{tweet}', [TweetController::class, 'detail'])->name('detail');
         //ツイート編集ページ表示
-        Route::get('edit/{tweet}', [TweetController::class, 'edit'])->name('.edit');
+        Route::get('edit/{tweet}', [TweetController::class, 'edit'])->name('edit');
         //ツイート編集
-        Route::put('update/{tweet}', [TweetController::class, 'update'])->name('.update');
+        Route::put('update/{tweet}', [TweetController::class, 'update'])->name('update');
         //ツイートの削除
-        Route::delete('delete/{tweet}', [TweetController::class, 'delete'])->name('.delete');
+        Route::delete('delete/{tweet}', [TweetController::class, 'delete'])->name('delete');
     });
 });

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -48,4 +48,8 @@ Route::group(['middleware' => 'auth'], function () {
         //ツイート詳細表示
         Route::get('detail', [TweetController::class, 'detail'])->name('.detail');
     });
+    //フォロー
+    Route::post('follow/{user}', [UserController::class, 'follow'])->name('follow');
+    //フォロー解除
+    Route::delete('unfollow/{user}', [UserController::class, 'unfollow'])->name('unfollow');
 });


### PR DESCRIPTION
# 課題のリンク
**-フォロー機能の追加**

# 改修内容
**- ユーザー一覧画面(user/index.blade.php)にボタンを追加**
＜未フォローユーザーの場合＞
　　フォローボタンを表示

＜フォロー済ユーザーの場合＞
　　フォロー解除ボタンの表示

**- UserController.phpにfollowメソッドの追加**
＜未フォローユーザーに対し、followメソッドを実行した場合＞
　　Follower.php：保存
　　ユーザー一覧画面；「フォローしました！」と表示

＜フォロー済ユーザーに対し、followメソッドを実行した場合＞
　　ユーザー一覧画面；「既にフォローしています！」と表示

＜自分(ログインユーザー)に対し、followメソッドを実行した場合＞
　　FollowPolicy；folseを出力
　　ユーザー一覧画面；「フォローに失敗しました！」と表示

**- UserController.phpにunfollowメソッドの追加**
followメソッドと同様の場合分けで実行
データの復元をすることはないと考え、物理削除を実装
※フォロー解除時のポリシーを作成していないのは、自己フォローができないようになっているため

# キャプチャ



https://github.com/keeee21/twitter-clone/assets/116775795/bb3458c2-cec3-4783-a856-9a51262b7a36





# 検証内容
- ブラウザ上において目視で確認